### PR TITLE
fix: add fuzz + improve newline handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test:
 test/fuzz:
 	go test -fuzz=FuzzJTOH
 
-.PHONY: test/fuzz/properties
+.PHONY: test/fuzz/valid
 test/fuzz/valid:
 	go test -fuzz=FuzzJTOHValid
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ test:
 test/fuzz:
 	go test -fuzz=FuzzJTOH
 
+.PHONY: test/fuzz/properties
+test/fuzz/valid:
+	go test -fuzz=FuzzJTOHValid
+
 .PHONY: bench
 bench: name?=.
 bench:

--- a/jtoh.go
+++ b/jtoh.go
@@ -137,7 +137,7 @@ func selectField(selector string, obj map[string]interface{}) string {
 		return missingFieldErrMsg(selector)
 	}
 
-	return strings.Trim(fmt.Sprint(v), "\n ")
+	return strings.Replace(fmt.Sprint(v), "\n", "\\n", -1)
 }
 
 func missingFieldErrMsg(selector string) string {

--- a/jtoh_fuzz_test.go
+++ b/jtoh_fuzz_test.go
@@ -122,21 +122,35 @@ func FuzzJTOHValid(f *testing.F) {
 			return
 		}
 
-		selector := ":" + key
+		// key/value may change on marshalling, so we get the actual
+		// final key/value from the json encoding/decoding process.
+		parsedInput := map[string]string{}
+		if err = json.Unmarshal(input, &parsedInput); err != nil {
+			t.Fatal(err)
+		}
+
+		var selectKey, wantValue string
+
+		for k, v := range parsedInput {
+			selectKey = k
+			wantValue = v
+		}
+
+		selector := ":" + selectKey
 
 		j, err := jtoh.New(selector)
 		if err != nil {
 			t.Fatal(err)
-			return
 		}
 
 		output := &bytes.Buffer{}
 		j.Do(bytes.NewReader(input), output)
 
-		want := val + "\n"
+		want := wantValue + "\n"
 		got := output.String()
 		if got != want {
-			t.Fatalf("got %q != %q", got, want)
+			t.Errorf("str  : got %q != want %q", got, want)
+			t.Errorf("bytes: got %v != want %v", []byte(got), []byte(want))
 		}
 	})
 }

--- a/jtoh_fuzz_test.go
+++ b/jtoh_fuzz_test.go
@@ -146,18 +146,26 @@ func FuzzJTOHValid(f *testing.F) {
 			t.Fatal(err)
 		}
 
-		output := &bytes.Buffer{}
-		j.Do(bytes.NewReader(input), output)
-
 		// Newlines on values are escaped to avoid breaking the
 		// line oriented nature of the output.
-
 		wantValue = strings.Replace(wantValue, "\n", "\\n", -1)
 		want := wantValue + "\n"
-		got := output.String()
-		if got != want {
-			t.Errorf("str  : got %q != want %q", got, want)
-			t.Errorf("bytes: got %v != want %v", []byte(got), []byte(want))
+
+		testSelection := func(input []byte) {
+			output := &bytes.Buffer{}
+			j.Do(bytes.NewReader(input), output)
+
+			got := output.String()
+			if got != want {
+				t.Errorf("input: %q", string(input))
+				t.Errorf("str  : got %q != want %q", got, want)
+				t.Errorf("bytes: got %v != want %v", []byte(got), []byte(want))
+			}
 		}
+
+		// Selecting on single document/stream must behave identically to
+		// selecting from a list of documents.
+		testSelection(input)
+		testSelection([]byte("[" + string(input) + "]"))
 	})
 }

--- a/jtoh_fuzz_test.go
+++ b/jtoh_fuzz_test.go
@@ -109,10 +109,13 @@ func FuzzJTOHValid(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, key string, val string) {
+		// Since field selectors have spaces trimmed for now we also
+		// trim the key, or else we would not be able to select the key.
+		key = strings.TrimSpace(key)
 		if key == "" {
 			return
 		}
-		if strings.Contains(key, ".") {
+		if strings.ContainsAny(key, ".:") {
 			// We don't handle nesting/keys with dot on name for now.
 			return
 		}
@@ -146,6 +149,10 @@ func FuzzJTOHValid(f *testing.F) {
 		output := &bytes.Buffer{}
 		j.Do(bytes.NewReader(input), output)
 
+		// Newlines on values are escaped to avoid breaking the
+		// line oriented nature of the output.
+
+		wantValue = strings.Replace(wantValue, "\n", "\\n", -1)
 		want := wantValue + "\n"
 		got := output.String()
 		if got != want {

--- a/jtoh_test.go
+++ b/jtoh_test.go
@@ -129,6 +129,14 @@ func TestTransform(t *testing.T) {
 			output:   []string{fmt.Sprintf("hi:7:%s:false", missingFieldErrMsg("missing"))},
 		},
 		{
+			// There is no way to project a key that has . inside.
+			// This is not a desirable limitation, but we have it for now.
+			name:     "NestedAccessWontMatchSingleFieldWithDot",
+			selector: ":nested.val",
+			input:    []string{`{"nested.val" : "value" }`},
+			output:   []string{missingFieldErrMsg("nested.val")},
+		},
+		{
 			name:     "IncompletePathToField",
 			selector: ":nested.number",
 			input:    []string{`{"nested" : {} }`},

--- a/jtoh_test.go
+++ b/jtoh_test.go
@@ -202,31 +202,31 @@ func TestTransform(t *testing.T) {
 			output:   []string{"666:stonks"},
 		},
 		{
-			name:     "TrailingNewlinesOnValuesAreTrimmed",
+			name:     "TrailingNewlinesOnValuesAreEscaped",
 			selector: ":field",
 			input: []string{
 				"{\"field\":\"\\nvalue1\\n\\n\"}",
 				"{\"field\":\"\\nvalue2\"}",
 			},
-			output: []string{"value1", "value2"},
+			output: []string{"\\nvalue1\\n\\n", "\\nvalue2"},
 		},
 		{
-			name:     "TrailingSpacesOnValuesAreTrimmed",
+			name:     "TrailingSpacesOnValuesArePreserved",
 			selector: ":field",
 			input: []string{
 				`{"field":" stonks "}`,
 				`{"field":"    stonks 2   "}`,
 			},
-			output: []string{"stonks", "stonks 2"},
+			output: []string{" stonks ", "    stonks 2   "},
 		},
 		{
-			name:     "NewlinesInsideValuesWillBePreserved",
+			name:     "NewlinesInsideValuesWillBeEscaped",
 			selector: ":field",
 			input: []string{
 				"{\"field\":\"BeforeNewline\\nAfterNewline\"}",
 				"{\"field\":\"value2\"}",
 			},
-			output: []string{"BeforeNewline", "AfterNewline", "value2"},
+			output: []string{"BeforeNewline\\nAfterNewline", "value2"},
 		},
 		{
 			name:     "IfFirstItemIsNotJSONItIsEchoed",

--- a/testdata/fuzz/FuzzJTOHValid/2082b0fb41680115a6b2c43a0710350219993c254b7c367641a350803051101b
+++ b/testdata/fuzz/FuzzJTOHValid/2082b0fb41680115a6b2c43a0710350219993c254b7c367641a350803051101b
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("0")
+string("\x81")

--- a/testdata/fuzz/FuzzJTOHValid/31219d82bc17dee1e2b4221601a1719a076c4127496106b0e1131d689fb801f0
+++ b/testdata/fuzz/FuzzJTOHValid/31219d82bc17dee1e2b4221601a1719a076c4127496106b0e1131d689fb801f0
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("0")
+string(" ")

--- a/testdata/fuzz/FuzzJTOHValid/c4bc339a1557bf0054d47df406c6770d69b9ea4258c33903d5389411d5546c72
+++ b/testdata/fuzz/FuzzJTOHValid/c4bc339a1557bf0054d47df406c6770d69b9ea4258c33903d5389411d5546c72
@@ -1,0 +1,3 @@
+go test fuzz v1
+string(" ")
+string("0")

--- a/testdata/fuzz/FuzzJTOHValid/c4bc339a1557bf0054d47df406c6770d69b9ea4258c33903d5389411d5546c72
+++ b/testdata/fuzz/FuzzJTOHValid/c4bc339a1557bf0054d47df406c6770d69b9ea4258c33903d5389411d5546c72
@@ -1,3 +1,0 @@
-go test fuzz v1
-string(" ")
-string("0")


### PR DESCRIPTION
While fuzzying in a more structure aware way I realized some of the design around newlines was wrong and would break the output when json strings had escaped newlines inside and were decoded + sent to output. So far no other problems detected.